### PR TITLE
Change 'noob' level emojis from fruit to smiley faces

### DIFF
--- a/src/routes/levels.ts
+++ b/src/routes/levels.ts
@@ -10,7 +10,7 @@ export const levels: Level[] = [
 		label: 'noob',
 		size: 3,
 		duration: 30 * 1000,
-		emojis: '🍏 🍎 🍐 🍊 🍋 🍌 🍉 🍇 🍓'.split(' ')
+		emojis: '😀 😃 😄'.split(' ')
 	},
 	{
 		label: 'easy',


### PR DESCRIPTION
This PR updates the 'noob' level in levels.ts to use smiley face emojis (😀 😃 😄) instead of fruit emojis. This makes the level more visually consistent with the intended theme for beginners.