### PR TITLE
fix: adjust noob level difficulty

### DIFF
--- a/src/routes/levels.ts
+++ b/src/routes/levels.ts
@@ -8,8 +8,8 @@ export interface Level {
 export const levels: Level[] = [
 	{
 		label: 'noob',
-		size: 6,
-		duration: 30 * 1000,
+		size: 3,
+		duration: 45 * 1000,
 		emojis: '🍏 🍎 🍐 🍊 🍋 🍌 🍉 🍇 🍓 🫐 🍈 🍒 🍑 🥭 🍍 🥥 🥝 🍅'.split(' ')
 	},
 	{


### PR DESCRIPTION
This pull request adjusts the 'noob' level difficulty by setting its grid size to 3 and increasing the duration to 45 seconds. This also addresses the issue of an extra box appearing at the bottom of the grid for this level.